### PR TITLE
feat(ci): add TypeScript syntax validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main, v2]
+  pull_request:
+    branches: [main]
+
+jobs:
+  syntax-check:
+    name: TypeScript Syntax Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Validate TypeScript syntax
+        run: bun scripts/check-syntax.ts

--- a/scripts/check-syntax.ts
+++ b/scripts/check-syntax.ts
@@ -1,0 +1,28 @@
+/**
+ * TypeScript syntax validation using Bun's transpiler.
+ * Mirrors the pre-commit check in src/safe-commit.ts.
+ * Used by CI and can be run locally: bun scripts/check-syntax.ts
+ */
+const transpiler = new Bun.Transpiler({ loader: "ts" });
+const errors: string[] = [];
+let count = 0;
+
+for (const pattern of ["src/**/*.ts", "skills/**/*.ts"]) {
+  for await (const file of new Bun.Glob(pattern).scan(".")) {
+    count++;
+    try {
+      const content = await Bun.file(file).text();
+      transpiler.transformSync(content);
+    } catch (err) {
+      errors.push(`${file}: ${err}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Syntax errors in ${errors.length}/${count} files:`);
+  errors.forEach((e) => console.error(`  ${e}`));
+  process.exit(1);
+} else {
+  console.log(`${count} TypeScript files pass syntax validation`);
+}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI workflow that validates TypeScript syntax on every push to main/v2 and on PRs to main
- Creates `scripts/check-syntax.ts` using Bun's transpiler — mirrors the pre-commit check in `src/safe-commit.ts`
- Validates all `.ts` files in `src/` and `skills/` (211 files currently)

## Test plan
- [x] Verified locally: `bun scripts/check-syntax.ts` passes all 211 files
- [ ] CI workflow runs on this PR push
- [ ] Introduce a syntax error to verify CI catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)