### PR TITLE
feat(sensors): add publishing sensors to worker allowlist for Loom

### DIFF
--- a/src/sensors.ts
+++ b/src/sensors.ts
@@ -190,6 +190,11 @@ const WORKER_SENSORS: ReadonlySet<string> = new Set([
   "erc8004-reputation-monitor",  // watch for incoming on-chain feedback (60min)
   // GitHub policy enforcement — intercept blocked GitHub tasks and route to Arc
   "github-interceptor",          // auto-handoff GitHub work to Arc (10min)
+  // Publishing — Loom needs these for AIBTC publisher role
+  "aibtc-news-editorial",        // editorial signal detection
+  "blog-publishing",             // blog content generation
+  "blog-deploy",                 // deploy published content
+  "blog-x-syndication",          // syndicate posts to X
 ]);
 
 /** Per-sensor timeout in milliseconds. Liberal limit to catch hangs, not rush normal work. */


### PR DESCRIPTION
## Summary
- Adds `aibtc-news-editorial`, `blog-publishing`, `blog-deploy`, `blog-x-syndication` to the `WORKER_SENSORS` allowlist in `src/sensors.ts`
- Enables Loom to run publishing-domain sensors as part of its AIBTC publisher role (v6 roadmap task #6710)

## Test plan
- [ ] Verify `bun build src/sensors.ts --no-bundle` passes (confirmed locally)
- [ ] Confirm Loom picks up the 4 new sensors on next sensor cycle
- [ ] Verify Arc still runs all sensors (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)