### PR TITLE
feat(wallet): add sbtc-transfer subcommand to wallet CLI

### DIFF
--- a/skills/bitcoin-wallet/SKILL.md
+++ b/skills/bitcoin-wallet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bitcoin-wallet
-description: Wallet management, cryptographic signing, and STX transfers for Stacks and Bitcoin — unlock, lock, info, status, BTC/Stacks message signing, BTC signature verification, and STX sending.
-updated: 2026-03-09
+description: Wallet management, cryptographic signing, STX transfers, and sBTC transfers for Stacks and Bitcoin — unlock, lock, info, status, BTC/Stacks message signing, BTC signature verification, STX sending, and sBTC transfers.
+updated: 2026-04-05
 tags:
   - infrastructure
   - sensitive
@@ -33,6 +33,7 @@ arc skills run --name wallet -- btc-sign --message "text"
 arc skills run --name wallet -- stacks-sign --message "text"
 arc skills run --name wallet -- btc-verify --message "text" --signature "sig" [--expected-signer "addr"]
 arc skills run --name wallet -- stx-send --recipient <STX address> --amount-stx <number> [--memo "text"]
+arc skills run --name wallet -- sbtc-transfer --recipient <STX address> --amount <sats> [--memo "text"] [--sponsored]
 arc skills run --name wallet -- check-relay-health [--relay-url <url>] [--sponsor-address <address>]
 arc skills run --name wallet -- x402 <x402-subcommand> [flags]
 ```
@@ -74,6 +75,20 @@ Send STX to a recipient address. Auto-unlocks and locks the wallet internally.
 
 **Example:** `arc skills run --name wallet -- stx-send --recipient SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE --amount-stx 2`
 
+### sbtc-transfer
+
+Transfer sBTC to a recipient Stacks address. Auto-unlocks and locks the wallet internally. Uses the upstream `sbtc.service.ts` transfer method.
+
+**Flags:**
+- `--recipient` (required): Stacks address (SP... for mainnet, ST... for testnet)
+- `--amount` (required): Amount in satoshis (e.g. `100000` for 0.001 sBTC). 1 sBTC = 100,000,000 satoshis.
+- `--memo` (optional): Memo string to attach to the transfer (max 34 bytes).
+- `--sponsored` (optional): Use fee sponsorship if available.
+
+**Output:** JSON with `success`, `txid`, `from`, `recipient`, `amount_sbtc`, `amount_sats`, `explorer` URL.
+
+**Example:** `arc skills run --name wallet -- sbtc-transfer --recipient SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE --amount 30000`
+
 ### check-relay-health
 
 Check x402 sponsor relay health and sponsor nonce status. Queries the relay `/health` endpoint and fetches sponsor nonce data from the Hiro API. Detects nonce gaps (transactions may be stuck) and mempool congestion (pending transactions). Reports relay reachability, sponsor nonce state, and any issues. No unlock required.
@@ -93,6 +108,7 @@ Example: `arc skills run --name wallet -- x402 send-inbox-message --recipient-bt
 ## When to Use
 
 - **Funding agent wallets** — Send STX to other agent addresses via `stx-send`.
+- **Paying correspondents** — Distribute sBTC payouts to contributors via `sbtc-transfer`.
 - **AIBTC inbox messages** — Send paid x402 messages via `x402 send-inbox-message`.
 - **AIBTC heartbeat check-ins** — BTC sign the check-in message, then lock.
 - **Proving identity** — Sign a message to prove ownership of arc0.btc addresses.

--- a/skills/bitcoin-wallet/cli.ts
+++ b/skills/bitcoin-wallet/cli.ts
@@ -18,6 +18,7 @@ const SIGN_RUNNER = resolve(import.meta.dir, "sign-runner.ts");
 const X402_RUNNER = resolve(import.meta.dir, "x402-runner.ts");
 const BNS_RUNNER = resolve(import.meta.dir, "bns-runner.ts");
 const STX_SEND_RUNNER = resolve(import.meta.dir, "stx-send-runner.ts");
+const SBTC_TRANSFER_RUNNER = resolve(import.meta.dir, "sbtc-transfer-runner.ts");
 
 // ---- Helpers ----
 
@@ -590,6 +591,121 @@ async function cmdStxSend(args: string[]): Promise<void> {
   }
 }
 
+/**
+ * Run an sBTC transfer command via the sbtc-transfer-runner, which handles
+ * unlock + transfer + lock in a single process (required because wallet
+ * manager session is in-memory).
+ * Uses timeout approach because the wallet auto-lock timer keeps the process alive.
+ */
+async function runSbtcTransfer(transferArgs: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const password = await getWalletPassword();
+  const walletId = await getWalletId();
+
+  const proc = Bun.spawn(["bun", "run", SBTC_TRANSFER_RUNNER, ...transferArgs], {
+    cwd: ROOT,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      WALLET_ID: walletId,
+      WALLET_PASSWORD: password,
+      NETWORK: "mainnet",
+    },
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  const stderrPromise = new Response(proc.stderr).text().then((t) => { stderr = t; });
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+
+  const readWithTimeout = new Promise<string>(async (resolve, reject) => {
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Timeout waiting for sbtc-transfer response (60s)"));
+    }, 60000);
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stdout += decoder.decode(value, { stream: true });
+
+        const trimmed = stdout.trim();
+        if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+          try {
+            JSON.parse(trimmed);
+            clearTimeout(timer);
+            proc.kill();
+            resolve(trimmed);
+            return;
+          } catch {
+            // Incomplete JSON, keep reading
+          }
+        }
+      }
+      clearTimeout(timer);
+      resolve(stdout.trim());
+    } catch (error) {
+      clearTimeout(timer);
+      reject(error);
+    }
+  });
+
+  const result = await readWithTimeout;
+  await stderrPromise.catch(() => {});
+
+  let exitCode = 0;
+  try {
+    const parsed = JSON.parse(result) as Record<string, unknown>;
+    if (parsed.error || parsed.success === false) {
+      exitCode = 1;
+    }
+  } catch {
+    exitCode = 1;
+  }
+
+  return { stdout: result, stderr: stderr.trim(), exitCode };
+}
+
+async function cmdSbtcTransfer(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+
+  if (!flags.recipient || !flags.amount) {
+    process.stderr.write("Usage: arc skills run --name wallet -- sbtc-transfer --recipient <STX address> --amount <sats> [--memo \"text\"] [--sponsored]\n");
+    process.exit(1);
+  }
+
+  log(`transferring ${flags.amount} sats sBTC to ${flags.recipient} (auto unlock/lock)`);
+  try {
+    const transferArgs = ["--recipient", flags.recipient, "--amount", flags.amount];
+    if (flags.memo) {
+      transferArgs.push("--memo", flags.memo);
+    }
+    if (flags.sponsored) {
+      transferArgs.push("--sponsored");
+    }
+
+    const result = await runSbtcTransfer(transferArgs);
+
+    if (result.exitCode !== 0) {
+      log(`sbtc-transfer failed: ${result.stderr}`);
+      console.log(JSON.stringify({ success: false, error: "sBTC transfer failed", detail: result.stderr || result.stdout }));
+      process.exit(1);
+    }
+
+    console.log(result.stdout);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`sbtc-transfer failed: ${message}`);
+    console.log(JSON.stringify({ success: false, error: "sBTC transfer failed", detail: message }));
+    process.exit(1);
+  }
+}
+
 async function cmdCheckRelayHealth(args: string[]): Promise<void> {
   const flags = parseFlags(args);
   const relayUrl = (flags["relay-url"] || "https://x402-relay.aibtc.com").replace(/\/+$/, "");
@@ -738,6 +854,10 @@ SUBCOMMANDS
     Send STX to a recipient. Auto-unlocks and locks.
     Amount is in STX (e.g. 2.5 = 2,500,000 micro-STX).
 
+  sbtc-transfer --recipient <STX address> --amount <sats> [--memo "text"] [--sponsored]
+    Transfer sBTC to a recipient. Auto-unlocks and locks.
+    Amount is in satoshis (e.g. 100000 = 0.001 sBTC).
+
   check-relay-health [--relay-url <url>] [--sponsor-address <address>]
     Check x402 sponsor relay health and nonce status (no unlock needed).
     Default relay: https://x402-relay.aibtc.com
@@ -761,6 +881,8 @@ EXAMPLES
   arc skills run --name wallet -- check-relay-health --relay-url "https://custom-relay.com" --sponsor-address "SP1CUSTOM..."
   arc skills run --name wallet -- stx-send --recipient SP... --amount-stx 2
   arc skills run --name wallet -- stx-send --recipient SP... --amount-stx 0.5 --memo "funding"
+  arc skills run --name wallet -- sbtc-transfer --recipient SP... --amount 100000
+  arc skills run --name wallet -- sbtc-transfer --recipient SP... --amount 30000 --memo "payout" --sponsored
   arc skills run --name wallet -- x402 send-inbox-message --recipient-btc-address bc1... --recipient-stx-address SP... --content "Hello"
 `);
 }
@@ -798,6 +920,9 @@ async function main(): Promise<void> {
       break;
     case "stx-send":
       await cmdStxSend(args.slice(1));
+      break;
+    case "sbtc-transfer":
+      await cmdSbtcTransfer(args.slice(1));
       break;
     case "check-relay-health":
       await cmdCheckRelayHealth(args.slice(1));

--- a/skills/bitcoin-wallet/sbtc-transfer-runner.ts
+++ b/skills/bitcoin-wallet/sbtc-transfer-runner.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+// skills/bitcoin-wallet/sbtc-transfer-runner.ts
+// Internal runner that unlocks the wallet and transfers sBTC in the same process.
+// The wallet manager singleton holds unlock state in memory, so unlock + transfer
+// must share a process.
+//
+// Usage (called by cli.ts, not directly):
+//   WALLET_ID=... WALLET_PASSWORD=... bun skills/bitcoin-wallet/sbtc-transfer-runner.ts --recipient SP... --amount 100000 [--memo "text"] [--sponsored]
+
+import { getWalletManager } from "../../github/aibtcdev/skills/src/lib/services/wallet-manager.js";
+import { getSbtcService } from "../../github/aibtcdev/skills/src/lib/services/sbtc.service.js";
+import type { Account } from "../../github/aibtcdev/skills/src/lib/transactions/builder.js";
+
+const walletId = process.env.WALLET_ID;
+const walletPassword = process.env.WALLET_PASSWORD;
+const network = (process.env.NETWORK || "mainnet") as "mainnet" | "testnet";
+
+if (!walletId || !walletPassword) {
+  console.log(JSON.stringify({ success: false, error: "WALLET_ID and WALLET_PASSWORD env vars required" }));
+  process.exit(1);
+}
+
+// Parse flags
+function parseFlags(args: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--")) {
+      const key = args[i].slice(2);
+      if (i + 1 >= args.length || args[i + 1].startsWith("--")) {
+        flags[key] = "true";
+      } else {
+        flags[key] = args[i + 1];
+        i++;
+      }
+    }
+  }
+  return flags;
+}
+
+const flags = parseFlags(process.argv.slice(2));
+
+if (!flags.recipient || !flags.amount) {
+  console.log(JSON.stringify({ success: false, error: "Missing required flags: --recipient and --amount" }));
+  process.exit(1);
+}
+
+const recipient = flags.recipient;
+const amountSats = BigInt(flags.amount);
+
+if (amountSats <= 0n) {
+  console.log(JSON.stringify({ success: false, error: `Invalid amount: ${flags.amount}. Must be a positive integer (satoshis).` }));
+  process.exit(1);
+}
+
+// Validate recipient address format (basic check for Stacks addresses)
+if (!recipient.startsWith("SP") && !recipient.startsWith("ST")) {
+  console.log(JSON.stringify({ success: false, error: `Invalid recipient address: must start with SP (mainnet) or ST (testnet)` }));
+  process.exit(1);
+}
+
+const memo = flags.memo || undefined;
+const sponsored = flags.sponsored === "true";
+
+// Unlock wallet manager singleton
+const wm = getWalletManager();
+
+try {
+  await wm.unlock(walletId, walletPassword);
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.log(JSON.stringify({ success: false, error: "Unlock failed", detail: msg }));
+  process.exit(1);
+}
+
+try {
+  const account = wm.getAccount() as Account;
+  const sbtcService = getSbtcService(network);
+
+  const result = await sbtcService.transfer(
+    account,
+    recipient,
+    amountSats,
+    memo,
+    undefined, // fee — let the service auto-estimate
+    sponsored
+  );
+
+  const btcAmount = Number(amountSats) / 100_000_000;
+
+  console.log(JSON.stringify({
+    success: true,
+    txid: result.txid,
+    from: account.address,
+    recipient,
+    amount_sbtc: btcAmount.toFixed(8) + " sBTC",
+    amount_sats: amountSats.toString(),
+    memo: memo || undefined,
+    sponsored,
+    explorer: `https://explorer.hiro.so/txid/${result.txid}?chain=${network}`,
+  }));
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.log(JSON.stringify({ success: false, error: "sBTC transfer failed", detail: msg }));
+} finally {
+  wm.lock();
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

- Add `sbtc-transfer` subcommand to the bitcoin-wallet CLI, unblocking the payout distribution pipeline (`PayoutDistributionMachine`) that references this command
- Create `sbtc-transfer-runner.ts` following the existing `stx-send-runner.ts` pattern: unlock wallet, call upstream `sbtc.service.ts` transfer, lock wallet — all in one process
- Register `sbtc-transfer` in CLI switch statement, usage text, and SKILL.md documentation

## Details

**New files:**
- `skills/bitcoin-wallet/sbtc-transfer-runner.ts` — handles unlock + sBTC transfer + lock in a single process (required because wallet manager session is in-memory)

**Modified files:**
- `skills/bitcoin-wallet/cli.ts` — adds `runSbtcTransfer()`, `cmdSbtcTransfer()`, switch case, and usage text
- `skills/bitcoin-wallet/SKILL.md` — documents the new subcommand with flags, output format, and examples

**CLI interface:**
```
arc skills run --name wallet -- sbtc-transfer --recipient <STX address> --amount <sats> [--memo "text"] [--sponsored]
```

Closes #15

## Test plan

- [ ] Verify `arc skills run --name wallet -- help` shows `sbtc-transfer` in usage text
- [ ] Test with valid flags: `--recipient SP... --amount 1000`
- [ ] Test error handling: missing `--recipient`, missing `--amount`, invalid address prefix
- [ ] Test optional `--memo` and `--sponsored` flags
- [ ] Verify JSON output matches documented format (`success`, `txid`, `from`, `recipient`, `amount_sbtc`, `amount_sats`, `explorer`)
- [ ] Confirm the payout pipeline state machine can invoke the command without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)